### PR TITLE
Added logic to allow public ALB, parameterised the ALB listener port, updated the version requirements 

### DIFF
--- a/examples/prereqs_quickstart/aws-vpc/main.tf
+++ b/examples/prereqs_quickstart/aws-vpc/main.tf
@@ -5,6 +5,7 @@ module "vpc" {
   cidr                   = var.vpc_cidr
   azs                    = var.azs
   enable_nat_gateway     = true
+  single_nat_gateway     = var.single_nat_gateway
   one_nat_gateway_per_az = true
   private_subnets        = var.private_subnet_cidrs
   public_subnets         = var.public_subnet_cidrs

--- a/examples/prereqs_quickstart/aws-vpc/variables.tf
+++ b/examples/prereqs_quickstart/aws-vpc/variables.tf
@@ -39,3 +39,8 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
+variable "single_nat_gateway" {
+  type        = bool
+  default     = false
+  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+}

--- a/examples/prereqs_quickstart/versions.tf
+++ b/examples/prereqs_quickstart/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.1"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 3.0.0, <= 4.23.0"

--- a/examples/prereqs_quickstart/versions.tf
+++ b/examples/prereqs_quickstart/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.2.1"
 
   required_providers {
-    aws = ">= 3.0.0, < 4.0.0"
+    aws = ">= 3.0.0, <= 4.23.0"
     tls = ">= 3.0.0, < 4.0.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,10 @@ module "kms" {
   user_supplied_kms_key_arn = var.user_supplied_kms_key_arn
 }
 
+locals {
+  lb_subnet_ids = var.is_vault_lb_internal ? var.private_subnet_ids : var.public_subnet_ids
+}
+
 module "loadbalancer" {
   source = "./modules/load_balancer"
 
@@ -28,12 +32,14 @@ module "loadbalancer" {
   lb_certificate_arn      = var.lb_certificate_arn
   lb_deregistration_delay = var.lb_deregistration_delay
   lb_health_check_path    = var.lb_health_check_path
-  lb_subnets              = var.private_subnet_ids
+  lb_subnets              = var.lb_subnet_ids
   lb_type                 = var.lb_type
   resource_name_prefix    = var.resource_name_prefix
   ssl_policy              = var.ssl_policy
   vault_sg_id             = module.vm.vault_sg_id
   vpc_id                  = module.networking.vpc_id
+  is_vault_lb_internal    = var.is_vault_lb_internal
+  lb_listener_port        = var.lb_listener_port
 }
 
 module "networking" {

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "loadbalancer" {
   lb_certificate_arn      = var.lb_certificate_arn
   lb_deregistration_delay = var.lb_deregistration_delay
   lb_health_check_path    = var.lb_health_check_path
-  lb_subnets              = var.lb_subnet_ids
+  lb_subnets              = local.lb_subnet_ids
   lb_type                 = var.lb_type
   resource_name_prefix    = var.resource_name_prefix
   ssl_policy              = var.ssl_policy

--- a/modules/load_balancer/main.tf
+++ b/modules/load_balancer/main.tf
@@ -12,11 +12,11 @@ resource "aws_security_group" "vault_lb" {
 
 resource "aws_security_group_rule" "vault_lb_inbound" {
   count             = var.lb_type == "application" && var.allowed_inbound_cidrs != null ? 1 : 0
-  description       = "Allow specified CIDRs access to load balancer on port 8200"
+  description       = "Allow specified CIDRs access to load balancer on port ${var.lb_listener_port}"
   security_group_id = aws_security_group.vault_lb[0].id
   type              = "ingress"
-  from_port         = 8200
-  to_port           = 8200
+  from_port         = var.lb_listener_port
+  to_port           = var.lb_listener_port
   protocol          = "tcp"
   cidr_blocks       = var.allowed_inbound_cidrs
 }
@@ -39,7 +39,7 @@ locals {
 
 resource "aws_lb" "vault_lb" {
   name                       = "${var.resource_name_prefix}-vault-lb"
-  internal                   = true
+  internal                   = var.is_vault_lb_internal
   load_balancer_type         = var.lb_type
   subnets                    = var.lb_subnets
   security_groups            = local.lb_security_groups
@@ -76,7 +76,7 @@ resource "aws_lb_target_group" "vault" {
 
 resource "aws_lb_listener" "vault" {
   load_balancer_arn = aws_lb.vault_lb.id
-  port              = 8200
+  port              = var.lb_listener_port
   protocol          = local.lb_protocol
   ssl_policy        = local.lb_protocol == "HTTPS" ? var.ssl_policy : null
   certificate_arn   = local.lb_protocol == "HTTPS" ? var.lb_certificate_arn : null

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -55,3 +55,15 @@ variable "vpc_id" {
   type        = string
   description = "VPC ID where Vault will be deployed"
 }
+
+variable "is_vault_lb_internal" {
+  type        = bool
+  default     = true
+  description = "Whether the Vault load balancer is internal or not. if 'true' the ALB will be internal else if 'false' the ALB will be external"
+}
+
+variable "lb_listener_port" {
+  type        = number
+  default     = 8200
+  description = "Load balancer listener port where Vault would be accessible"
+}

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -159,6 +159,17 @@ resource "aws_autoscaling_group" "vault" {
     version = "$Latest"
   }
 
+  dynamic "tag" {
+    for_each = local.tags
+    content {
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = tag.value.propagate_at_launch
+    }
+  }
+}
+
+locals {
   tags = concat(
     [
       {

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,21 @@ variable "vpc_id" {
   type        = string
   description = "VPC ID where Vault will be deployed"
 }
+
+variable "is_vault_lb_internal" {
+  type        = bool
+  default     = true
+  description = "Whether the Vault load balancer is internal or not. if 'true' the ALB will be internal else if 'false' the ALB will be external"
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Subnet IDs to deploy Vault ALB into if 'is_vault_lb_internal' is false. i.e When creating a public load balancer for Vault"
+}
+
+variable "lb_listener_port" {
+  type        = number
+  default     = 8200
+  description = "Load balancer listener port where Vault would be accessible"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.2.1"
 
   required_providers {
-    aws = ">= 3.0.0, < 4.0.0"
+    aws = ">= 3.0.0, <= 4.23.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.1"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 3.0.0, <= 4.23.0"


### PR DESCRIPTION
- Added logic to allow creation of Public ALB if needed.
- parameterised the ALB listener port
- Allowed creation of Single NAT Gateway
- Updated the version constraints
- Changing the logic to pass 'tags' to 'aws_autoscaling_group'  resource as 'tags' argument is deprecated.
- closes #39 
- closes #38  